### PR TITLE
update dns-dump LDAP URIs

### DIFF
--- a/dns-dump.ps1
+++ b/dns-dump.ps1
@@ -22,6 +22,8 @@ Param(
 	[string]$domain,
 	[string]$dc,
 	[switch]$csv,
+	[switch]$forest,
+	[switch]$legacy,
 	[switch]$help
 )
 
@@ -591,8 +593,17 @@ Example 3:
 
 	$dn = "LDAP://"
 	if ($dc) { $dn += $dc + "/" }
-	$dn += "DC=" + $zone + ",CN=MicrosoftDNS,CN=System," + $defaultNC
-
+	
+	if ($legacy) {
+		$dn += "DC=" + $zone + ",CN=MicrosoftDNS,CN=System," + $defaultNC
+	}
+	elseif ($forest) {
+		$dn += "DC=" + $zone + ",CN=MicrosoftDNS,DC=ForestDnsZones," + $defaultNC
+	}
+	else {
+		$dn += "DC=" + $zone + ",CN=MicrosoftDNS,DC=DomainDnsZones," + $defaultNC
+	}
+	
 	$obj = [ADSI]$dn
 	if ($obj.name)
 	{


### PR DESCRIPTION
I updated the LDAP URIs of dns-dump, since it didn't work in modern systems. I based the updates in [those from adidnsdump](https://github.com/dirkjanm/adidnsdump/blob/master/adidnsdump/dnsdump.py#L397).